### PR TITLE
Issue #2 - Print version information.  Use buildinfo plugin to levera…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,3 +44,10 @@ artifact in (Compile, assembly) := {
 }
 
 addArtifact(artifact in (Compile, assembly), assembly)
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "au.com.agiledigital.toolform.version"
+  )

--- a/project/buildinfo.sbt
+++ b/project/buildinfo.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/project/buildinfo.sbt
+++ b/project/buildinfo.sbt
@@ -1,2 +1,0 @@
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 // For formatting of the source code.
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.12")

--- a/src/main/scala/au/com/agiledigital/toolform/app/ToolFormApp.scala
+++ b/src/main/scala/au/com/agiledigital/toolform/app/ToolFormApp.scala
@@ -3,6 +3,7 @@ package au.com.agiledigital.toolform.app
 import java.io.File
 
 import au.com.agiledigital.toolform.model._
+import au.com.agiledigital.toolform.version.BuildInfo
 import com.typesafe.config._
 import pureconfig._
 import pureconfig.error.{ConfigReaderFailures, KeyNotFound}
@@ -28,8 +29,8 @@ object ToolFormApp extends App {
     } yield summary
 
   private def parseCommandLineArgs(args: Array[String]): Either[ToolFormError, ToolFormConfiguration] = {
-    val parser = new scopt.OptionParser[ToolFormConfiguration]("toolform") {
-      head("toolform", "0.1")
+    val parser = new scopt.OptionParser[ToolFormConfiguration](BuildInfo.name) {
+      head(BuildInfo.name, BuildInfo.version)
       help("help").abbr("h").text("Displays this usage text.")
       version("version").abbr("v").text("Displays version information.")
       opt[File]('i', "inspect") required () valueName "<file>" action { (x, c) =>


### PR DESCRIPTION
…ge sbt project info so that we don't duplicate it in the code.